### PR TITLE
Make session cookie name configurable

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -49,17 +49,19 @@ data CookieSettings = CookieSettings
   {
   -- | 'Secure' means browsers will only send cookies over HTTPS. Default:
   -- @Secure@.
-    cookieIsSecure :: IsSecure
+    cookieIsSecure    :: IsSecure
   -- | How long from now until the cookie expires. Default: @Nothing@
-  , cookieMaxAge   :: Maybe DiffTime
+  , cookieMaxAge      :: Maybe DiffTime
   -- | At what time the cookie expires. Default: @Nothing@
-  , cookieExpires  :: Maybe UTCTime
+  , cookieExpires     :: Maybe UTCTime
   -- | 'SameSite' settings. Default: @SameSiteLax@.
-  , cookieSameSite :: SameSite
+  , cookieSameSite    :: SameSite
+  -- | What name to use for the cookie used for the session.
+  , sessionCookieName :: BS.ByteString
   -- | What name to use for the cookie used for CSRF protection.
-  , xsrfCookieName :: BS.ByteString
+  , xsrfCookieName    :: BS.ByteString
   -- | What name to use for the header used for CSRF protection.
-  , xsrfHeaderName :: BS.ByteString
+  , xsrfHeaderName    :: BS.ByteString
   } deriving (Eq, Show, Generic)
 
 instance Default CookieSettings where
@@ -67,12 +69,13 @@ instance Default CookieSettings where
 
 defaultCookieSettings :: CookieSettings
 defaultCookieSettings = CookieSettings
-    { cookieIsSecure = Secure
-    , cookieMaxAge   = Nothing
-    , cookieExpires  = Nothing
-    , cookieSameSite = SameSiteLax
-    , xsrfCookieName = "XSRF-TOKEN"
-    , xsrfHeaderName = "X-XSRF-TOKEN"
+    { cookieIsSecure    = Secure
+    , cookieMaxAge      = Nothing
+    , cookieExpires     = Nothing
+    , cookieSameSite    = SameSiteLax
+    , sessionCookieName = "JWT-Cookie"
+    , xsrfCookieName    = "XSRF-TOKEN"
+    , xsrfHeaderName    = "X-XSRF-TOKEN"
     }
 
 

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -27,8 +27,8 @@ cookieAuthCheck ccfg jwtCfg = do
     xsrfCookie <- lookup (xsrfCookieName ccfg) cookies
     xsrfHeader <- lookup (mk $ xsrfHeaderName ccfg) $ requestHeaders req
     guard $ xsrfCookie `constTimeEq` xsrfHeader
-    -- JWT-Cookie *must* be HttpOnly and Secure
-    lookup "JWT-Cookie" cookies
+    -- session cookie *must* be HttpOnly and Secure
+    lookup (sessionCookieName ccfg) cookies
   verifiedJWT <- liftIO $ runExceptT $ do
     unverifiedJWT <- Jose.decodeCompact $ BSL.fromStrict jwtCookie
     Jose.validateJWSJWT (jwtSettingsToJwtValidationSettings jwtCfg)
@@ -47,7 +47,7 @@ makeCookie cookieSettings jwtSettings v = do
   case ejwt of
     Left _ -> return Nothing
     Right jwt -> return $ Just $ def
-        { setCookieName = "JWT-Cookie"
+        { setCookieName = sessionCookieName cookieSettings
         , setCookieValue = BSL.toStrict jwt
         , setCookieHttpOnly = True
         , setCookieMaxAge = cookieMaxAge cookieSettings


### PR DESCRIPTION
Hi Julian,

Here's a change to make the session cookie name configurable, if you're interested in supporting that. The cookie name still defaults to `JWT-Cookie`.

Thanks,
Brian