### PR TITLE
Allow safe/stateless requests without CSRF token

### DIFF
--- a/servant-auth-server/package.yaml
+++ b/servant-auth-server/package.yaml
@@ -44,6 +44,7 @@ dependencies:
   - crypto-api              >= 0.13 && < 0.14
   - data-default-class      >= 0.0  && < 0.2
   - http-api-data           >= 0.2  && < 0.4
+  - http-types              >= 0.9  && < 0.10
 
 
 default-extensions:

--- a/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth-server/servant-auth-server.cabal
@@ -55,6 +55,7 @@ library
     , crypto-api              >= 0.13 && < 0.14
     , data-default-class      >= 0.0  && < 0.2
     , http-api-data           >= 0.2  && < 0.4
+    , http-types              >= 0.9  && < 0.10
   exposed-modules:
       Servant.Auth.Server
       Servant.Auth.Server.Internal
@@ -99,6 +100,7 @@ executable readme
     , crypto-api              >= 0.13 && < 0.14
     , data-default-class      >= 0.0  && < 0.2
     , http-api-data           >= 0.2  && < 0.4
+    , http-types              >= 0.9  && < 0.10
     , servant-auth
     , servant-auth-server
     , servant-server  >= 0.8 && < 0.10
@@ -137,6 +139,7 @@ test-suite spec
     , crypto-api              >= 0.13 && < 0.14
     , data-default-class      >= 0.0  && < 0.2
     , http-api-data           >= 0.2  && < 0.4
+    , http-types              >= 0.9  && < 0.10
     , servant-auth-server
     , hspec > 2 && < 3
     , QuickCheck >= 2.8 && < 2.9


### PR DESCRIPTION
This addresses #10.

It's probably also fine to leave this as-is (i.e. more conservative), but I figured people might expect to be able to perform `GET` requests without adding a CSRF token, as is common with other libraries/frameworks.

This change assumes that people will abide by RESTful patterns, and not perform state changes when issued a stateless method like `GET`, when they should be using `POST`, `PUT`, `PATCH`, etc.

Unfortunately this will have a minor conflict with the PR #12.