### PR TITLE
Change routing order for unprotected route

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ protected (Authenticated user) = return (name user) :<|> return (email user)
 protected _ = throwAll err401
 
 type Unprotected =
-     Raw
- :<|>   "login"
+ "login"
      :> ReqBody '[JSON] Login
      :> PostNoContent '[JSON] (Headers '[Header "Set-Cookie" SetCookie] NoContent)
+  :<|> Raw
 
 unprotected :: CookieSettings -> JWTSettings -> Server Unprotected
-unprotected cs jwts = serveDirectory "example/static" :<|> checkCreds cs jwts
+unprotected cs jwts = checkCreds cs jwts :<|> serveDirectory "example/static" 
 
 type API auths = (Auth auths User :> Protected) :<|> Unprotected
 

--- a/servant-auth-server/executables/README.lhs
+++ b/servant-auth-server/executables/README.lhs
@@ -71,13 +71,13 @@ protected (Authenticated user) = return (name user) :<|> return (email user)
 protected _ = throwAll err401
 
 type Unprotected =
-     Raw
- :<|>   "login"
+ "login"
      :> ReqBody '[JSON] Login
      :> PostNoContent '[JSON] (Headers '[Header "Set-Cookie" SetCookie] NoContent)
+  :<|> Raw
 
 unprotected :: CookieSettings -> JWTSettings -> Server Unprotected
-unprotected cs jwts = serveDirectory "example/static" :<|> checkCreds cs jwts
+unprotected cs jwts = checkCreds cs jwts :<|> serveDirectory "example/static" 
 
 type API auths = (Auth auths User :> Protected) :<|> Unprotected
 


### PR DESCRIPTION
The unprotected route in the example matches first on the `Raw` route and then on the `"login"` route. A query to the login route gives the following result:

    $ curl localhost:7249/login -v

    *   Trying 127.0.0.1...
    * Connected to localhost (127.0.0.1) port 7500 (#0)
    > GET /login HTTP/1.1
    > Host: localhost:7500
    > User-Agent: curl/7.47.1
    > Accept: */*
    > 
    < HTTP/1.1 404 Not Found
    < Transfer-Encoding: chunked
    < Date: Sun, 05 Feb 2017 12:12:54 GMT
    < Server: Warp/3.2.9
    < Content-Type: text/plain
    < 
    * Connection #0 to host localhost left intact
    File not found%    

If there is a file called `login` in the static folder the content of this file is served. 

    $ curl localhost:7249/login -v 

    *   Trying 127.0.0.1...
    * Connected to localhost (127.0.0.1) port 7500 (#0)
    > GET /login HTTP/1.1
    > Host: localhost:7500
    > User-Agent: curl/7.47.1
    > Accept: */*
    > 
    < HTTP/1.1 200 OK
    < Last-Modified: Sat, 04 Feb 2017 22:15:58 GMT
    < Content-Length: 10
    < Accept-Ranges: bytes
    < Date: Sun, 05 Feb 2017 12:12:40 GMT
    < Server: Warp/3.2.9
    < Content-Type: application/octet-stream
    < last-modified: Sat, 04 Feb 2017 22:15:58 GMT
    < 
    hello world
    * Connection #0 to host localhost left intact

After the change of the route order the login request is handled correctly. 

    $ curl -H "Content-Type: application/json" -d "{ \"username\": \"Ali baba\", \"password\": \"Open sesame\"}" localhost:7249/login -v

    *   Trying 127.0.0.1...
    * Connected to localhost (127.0.0.1) port 7500 (#0)
    > POST /login HTTP/1.1
    > Host: localhost:7500
    > User-Agent: curl/7.47.1
    > Accept: */*
    > Content-Type: application/json
    > Content-Length: 52
    > 
    * upload completely sent off: 52 out of 52 bytes
    < HTTP/1.1 204 No Content
    < Date: Sun, 05 Feb 2017 12:18:35 GMT
    < Server: Warp/3.2.9
    < Content-Type: application/json
    < Set-Cookie: JWT-Cookie=eyJhbGciOiJIUzI1NiJ9.eyJkYXQiOnsiZW1haWwiOiJhbGlAZW1haWwuY29tIiwibmFtZSI6IkFsaSBiYWJhIiwiaWQiOjF9fQ.cfrCyQM0JQhxoBGyjkw-voD28l8fZEBuCLiVhs6VcTk; HttpOnly; Secure
    < 
    * Connection #0 to host localhost left intact


