### PR TITLE
Expose function to set both session and CSRF cookie for creds-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ protected _ = throwAll err401
 type Unprotected =
  "login"
      :> ReqBody '[JSON] Login
-     :> PostNoContent '[JSON] (Headers '[Header "Set-Cookie" SetCookie] NoContent)
+     :> PostNoContent '[JSON] (Headers '[ Header "Set-Cookie" SetCookie
+                                        , Header "Set-Cookie" SetCookie]
+                                        NoContent)
   :<|> Raw
 
 unprotected :: CookieSettings -> JWTSettings -> Server Unprotected
@@ -202,17 +204,21 @@ mainWithCookies = do
 
 
 -- Here is the login handler
-checkCreds :: CookieSettings -> JWTSettings -> Login
-  -> Handler (Headers '[Header "Set-Cookie" SetCookie] NoContent)
+checkCreds :: CookieSettings
+           -> JWTSettings
+           -> Login
+           -> Handler (Headers '[ Header "Set-Cookie" SetCookie
+                                , Header "Set-Cookie" SetCookie]
+                               NoContent)
 checkCreds cookieSettings jwtSettings (Login "Ali Baba" "Open Sesame") = do
    -- Usually you would ask a database for the user info. This is just a
    -- regular servant handler, so you can follow your normal database access
    -- patterns (including using 'enter').
    let usr = User "Ali Baba" "ali@email.com"
-   mcookie <- liftIO $ makeCookie cookieSettings jwtSettings usr
-   case mcookie of
-     Nothing     -> throwError err401
-     Just cookie -> return $ addHeader cookie NoContent
+   mApplyCookies <- liftIO $ acceptLogin cookieSettings jwtSettings usr
+   case mApplyCookies of
+     Nothing           -> throwError err401
+     Just applyCookies -> return $ applyCookies NoContent
 checkCreds _ _ _ = throwError err401
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ type Unprotected =
      :> ReqBody '[JSON] Login
      :> PostNoContent '[JSON] (Headers '[ Header "Set-Cookie" SetCookie
                                         , Header "Set-Cookie" SetCookie]
-                                        NoContent)
+                                       NoContent)
   :<|> Raw
 
 unprotected :: CookieSettings -> JWTSettings -> Server Unprotected

--- a/servant-auth-server/src/Servant/Auth/Server.hs
+++ b/servant-auth-server/src/Servant/Auth/Server.hs
@@ -70,6 +70,7 @@ module Servant.Auth.Server
   , defaultCookieSettings
   , makeCookie
   , makeCookieBS
+  , acceptLogin
 
 
   -- ** Related types

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/AddSetCookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/AddSetCookie.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE UndecidableInstances       #-}
+
 module Servant.Auth.Server.Internal.AddSetCookie where
 
-import qualified Data.ByteString            as BS
-import qualified Data.ByteString.Base64     as BS64
 import           Servant
 
-import           System.Entropy             (getEntropy)
 import           Web.Cookie
 
 -- What are we doing here? Well, the idea is to add headers to the response,
@@ -60,6 +58,3 @@ instance {-# OVERLAPS #-}
   (AddSetCookies n a a', AddSetCookies n b b')
   => AddSetCookies n (a :<|> b) (a' :<|> b') where
   addSetCookies cookies (a :<|> b) = addSetCookies cookies a :<|> addSetCookies cookies b
-
-csrfCookie :: IO BS.ByteString
-csrfCookie = BS64.encode <$> getEntropy 32


### PR DESCRIPTION
This fixes #11, by adding a new function `acceptLogin` that is similar to `makeCookie`:

```haskell
makeCookie :: ToJWT v => CookieSettings -> JWTSettings -> v -> IO (Maybe SetCookie)
```

```haskell
acceptLogin :: ( ToJWT session
               , AddHeader "Set-Cookie" SetCookie response withOneCookie
               , AddHeader "Set-Cookie" SetCookie withOneCookie withTwoCookies )
            => CookieSettings
            -> JWTSettings
            -> session
            -> IO (Maybe (response -> withTwoCookies))`
```

This returns a function that applies both session and CSRF cookies to a response object. It's designed to be used in login handlers.

I've also updated the README to illustrate how to use this function:

```haskell
checkCreds :: CookieSettings
           -> JWTSettings
           -> Login
           -> Handler (Headers '[ Header "Set-Cookie" SetCookie
                                , Header "Set-Cookie" SetCookie]
                               NoContent)
checkCreds cookieSettings jwtSettings (Login "Ali Baba" "Open Sesame") = do
   -- Usually you would ask a database for the user info. This is just a
   -- regular servant handler, so you can follow your normal database access
   -- patterns (including using 'enter').
   let usr = User "Ali Baba" "ali@email.com"
   mApplyCookies <- liftIO $ acceptLogin cookieSettings jwtSettings usr
   case mApplyCookies of
     Nothing           -> throwError err401
     Just applyCookies -> return $ applyCookies NoContent
checkCreds _ _ _ = throwError err401
```

One slightly annoying thing is the repeated `Header "Set-Cookie" SetCookie` in the type signature, but I guess there's not much we can do about that.

Feel free to rename this `acceptLogin` function, or let me know if there's any other changes I can make.

Thanks,
Brian