### PR TITLE
servant-auth-swagger

### DIFF
--- a/servant-auth-swagger/.ghci
+++ b/servant-auth-swagger/.ghci
@@ -1,0 +1,1 @@
+:set -isrc -itest -idoctest/ghci-wrapper/src

--- a/servant-auth-swagger/LICENSE
+++ b/servant-auth-swagger/LICENSE
@@ -1,0 +1,31 @@
+Copyright Julian K. Arni (c) 2015
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Julian K. Arni nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/servant-auth-swagger/Setup.hs
+++ b/servant-auth-swagger/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/servant-auth-swagger/package.yaml
+++ b/servant-auth-swagger/package.yaml
@@ -1,0 +1,70 @@
+name:                servant-auth-swagger
+version:             0.2.6.0
+synopsis:            servant-swagger/servant-auth compatibility
+description:         Please see README.md
+homepage:            http://github.com/plow-technologies/servant-auth#readme
+license:             BSD3
+license-file:        LICENSE
+author:              Julian K. Arni
+maintainer:          jkarni@gmail.com
+category:            Web, Servant, Authentication
+copyright:           (c) Julian K. Arni
+github:              plow-technologies/servant-auth
+tested-with:         GHC == 7.10.2, GHC == 8.0.1
+
+ghc-options: -Wall
+
+extra-source-files:
+  - package.yaml
+
+dependencies:
+  - base >= 4.7 && < 4.10
+  - text
+  - servant-swagger
+  - swagger2 >= 2 && < 3
+  - servant
+  - servant-auth == 0.2.*
+  - lens
+
+
+default-extensions:
+  - AutoDeriveTypeable
+  - ConstraintKinds
+  - DataKinds
+  - DefaultSignatures
+  - DeriveFoldable
+  - DeriveFunctor
+  - DeriveGeneric
+  - DeriveTraversable
+  - FlexibleContexts
+  - FlexibleInstances
+  - FunctionalDependencies
+  - GADTs
+  - KindSignatures
+  - MultiParamTypeClasses
+  - OverloadedStrings
+  - RankNTypes
+  - ScopedTypeVariables
+  - TypeFamilies
+  - TypeOperators
+
+library:
+  source-dirs:      src
+  other-modules:    []
+
+tests:
+  spec:
+    main:            Spec.hs
+    source-dirs:     test
+    dependencies:
+      - servant-auth-swagger
+      - yaml
+      - hspec > 2 && < 3
+      - QuickCheck >= 2.8 && < 2.9
+  doctest:
+    main:            Doctest.hs
+    source-dirs:     test
+    dependencies:
+      - doctest >= 0.9 && < 0.12
+      - Glob >= 0.7 && < 0.8
+      - yaml == 0.8.*

--- a/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth-swagger/servant-auth-swagger.cabal
@@ -1,0 +1,90 @@
+-- This file has been generated from package.yaml by hpack version 0.15.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           servant-auth-swagger
+version:        0.2.6.0
+synopsis:       servant-swagger/servant-auth compatibility
+description:    Please see README.md
+category:       Web, Servant, Authentication
+homepage:       http://github.com/plow-technologies/servant-auth#readme
+bug-reports:    https://github.com/plow-technologies/servant-auth/issues
+author:         Julian K. Arni
+maintainer:     jkarni@gmail.com
+copyright:      (c) Julian K. Arni
+license:        BSD3
+license-file:   LICENSE
+tested-with:    GHC == 7.10.2, GHC == 8.0.1
+build-type:     Simple
+cabal-version:  >= 1.10
+
+extra-source-files:
+    package.yaml
+
+source-repository head
+  type: git
+  location: https://github.com/plow-technologies/servant-auth
+
+library
+  hs-source-dirs:
+      src
+  default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
+  ghc-options: -Wall
+  build-depends:
+      base >= 4.7 && < 4.10
+    , text
+    , servant-swagger
+    , swagger2 >= 2 && < 3
+    , servant
+    , servant-auth == 0.2.*
+    , lens
+  exposed-modules:
+      Servant.Auth.Swagger
+  default-language: Haskell2010
+
+test-suite doctest
+  type: exitcode-stdio-1.0
+  main-is: Doctest.hs
+  hs-source-dirs:
+      test
+  default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
+  ghc-options: -Wall
+  build-depends:
+      base >= 4.7 && < 4.10
+    , text
+    , servant-swagger
+    , swagger2 >= 2 && < 3
+    , servant
+    , servant-auth == 0.2.*
+    , lens
+    , doctest >= 0.9 && < 0.12
+    , Glob >= 0.7 && < 0.8
+    , yaml == 0.8.*
+  other-modules:
+      Servant.Auth.SwaggerSpec
+      Spec
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  hs-source-dirs:
+      test
+  default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
+  ghc-options: -Wall
+  build-depends:
+      base >= 4.7 && < 4.10
+    , text
+    , servant-swagger
+    , swagger2 >= 2 && < 3
+    , servant
+    , servant-auth == 0.2.*
+    , lens
+    , servant-auth-swagger
+    , yaml
+    , hspec > 2 && < 3
+    , QuickCheck >= 2.8 && < 2.9
+  other-modules:
+      Doctest
+      Servant.Auth.SwaggerSpec
+  default-language: Haskell2010

--- a/servant-auth-swagger/src/Servant/Auth/Swagger.hs
+++ b/servant-auth-swagger/src/Servant/Auth/Swagger.hs
@@ -1,0 +1,68 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Servant.Auth.Swagger
+  (
+  -- | The purpose of this package is provide the instance for 'servant-auth'
+  -- combinators needed for 'servant-swagger' documentation generation.
+  --
+  -- Currently only JWT and BasicAuth are supported.
+
+  -- * Re-export
+    JWT
+  , BasicAuth
+  , Auth
+  ) where
+
+import Control.Lens    ((&), (<>~))
+import Data.Proxy      (Proxy (Proxy))
+import Data.Swagger    (ApiKeyLocation (..), ApiKeyParams (..),
+                        SecurityRequirement (..), SecurityScheme (..),
+                        SecuritySchemeType (..), allOperations, security,
+                        securityDefinitions)
+import GHC.Exts        (fromList)
+import Servant.API     hiding (BasicAuth)
+import Servant.Auth
+import Servant.Swagger
+
+import qualified Data.Text as T
+
+instance (AllHasSecurity xs, HasSwagger api) => HasSwagger (Auth xs r :> api) where
+  toSwagger _
+    = toSwagger (Proxy :: Proxy api)
+        & securityDefinitions <>~ fromList secs
+        & allOperations.security <>~ secReqs
+    where
+      secs = securities (Proxy :: Proxy xs)
+      secReqs = [ SecurityRequirement (fromList [(s,[])]) | (s,_) <- secs]
+
+
+class HasSecurity x where
+  securityName :: Proxy x -> T.Text
+  securityScheme :: Proxy x -> SecurityScheme
+
+instance HasSecurity BasicAuth where
+  securityName _ = "BasicAuth"
+  securityScheme _ = SecurityScheme type_ (Just desc)
+    where
+      type_ = SecuritySchemeBasic
+      desc  = "Basic access authentication"
+
+instance HasSecurity JWT where
+  securityName _ = "JwtSecurity"
+  securityScheme _ = SecurityScheme type_ (Just desc)
+    where
+      type_ = SecuritySchemeApiKey (ApiKeyParams "Authorization" ApiKeyHeader)
+      desc  = "JSON Web Token-based API key"
+
+class AllHasSecurity (x :: [*]) where
+  securities :: Proxy x -> [(T.Text,SecurityScheme)]
+
+instance (HasSecurity x, AllHasSecurity xs) => AllHasSecurity (x ': xs) where
+  securities _ = (securityName px, securityScheme px) : securities pxs
+    where
+      px :: Proxy x
+      px = Proxy
+      pxs :: Proxy xs
+      pxs = Proxy
+
+instance AllHasSecurity '[] where
+  securities _ = []

--- a/servant-auth-swagger/test/Doctest.hs
+++ b/servant-auth-swagger/test/Doctest.hs
@@ -1,0 +1,26 @@
+module Main (main) where
+
+-- Runs doctest on all files in "src" dir. Assumes:
+--   (a) You are using hpack
+--   (b) The top-level "default-extensions" are the only extensions besides the
+--   ones in the files.
+
+import System.FilePath.Glob (glob)
+import Test.DocTest (doctest)
+import Data.Yaml
+
+newtype Exts = Exts { getExts :: [String] }
+  deriving (Eq, Show, Read)
+
+instance FromJSON Exts where
+  parseJSON (Object v) = Exts <$> v .: "default-extensions"
+  parseJSON _ = fail "expecting object"
+
+main :: IO ()
+main = do
+  hpack' <- decodeFile "package.yaml"
+  hpack <- case hpack' of
+    Nothing -> return $ Exts []
+    Just v  -> return v
+  files <- glob "src/**/*.hs"
+  doctest $ files ++ fmap ("-X" ++) (getExts hpack)

--- a/servant-auth-swagger/test/Servant/Auth/SwaggerSpec.hs
+++ b/servant-auth-swagger/test/Servant/Auth/SwaggerSpec.hs
@@ -1,0 +1,31 @@
+module Servant.Auth.SwaggerSpec (spec) where
+
+import Control.Lens
+import Data.Proxy
+import Servant.API
+import Servant.Auth.Swagger
+import Data.Swagger
+import Servant.Swagger
+import Test.Hspec
+
+spec :: Spec
+spec = describe "HasSwagger instance" $ do
+
+  let swag = toSwagger (Proxy :: Proxy API)
+
+  it "adds security definitions at the top level" $ do
+    length (swag ^. securityDefinitions) `shouldSatisfy` (> 0)
+
+  it "adds security at sub-apis" $ do
+    swag ^. security `shouldBe` []
+    show (swag ^. paths . at "/secure") `shouldContain` "JwtSecurity"
+    show (swag ^. paths . at "/insecure") `shouldNotContain` "JwtSecurity"
+
+-- * API
+
+type API =   "secure" :> Auth '[JWT] Int :> SecureAPI
+        :<|> "insecure" :> InsecureAPI
+
+type SecureAPI = Get '[JSON] Int :<|> ReqBody '[JSON] Int :> Post '[JSON] Int
+
+type InsecureAPI = SecureAPI

--- a/servant-auth-swagger/test/Spec.hs
+++ b/servant-auth-swagger/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - servant-auth-server
 - servant-auth-client
 - servant-auth-docs
+- servant-auth-swagger
 extra-deps:
 - aeson-0.11.2.1
 - bytestring-builder-0.10.8.1.0


### PR DESCRIPTION
This PR adds a new package, which supports `servant-swagger`.