### PR TITLE
add `cookiePath` and `xsrfCookiePath` settings to `CookieSettings`

### DIFF
--- a/servant-auth-server/src/Servant/Auth/Server/Internal.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal.hs
@@ -45,6 +45,7 @@ instance ( n ~ 'S ('S 'Z)
              , Cookie.setCookieSecure = case cookieIsSecure cookieSettings of
                   Secure -> True
                   NotSecure -> False
+             , Cookie.setCookiePath = xsrfCookiePath cookieSettings
              }
         cookies <- makeCookies authResult
         return (authResult, Just csrf `SetCookieCons` cookies)

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/ConfigTypes.hs
@@ -56,10 +56,12 @@ data CookieSettings = CookieSettings
   , cookieExpires     :: Maybe UTCTime
   -- | 'SameSite' settings. Default: @SameSiteLax@.
   , cookieSameSite    :: SameSite
+  , cookiePath        :: Maybe BS.ByteString
   -- | What name to use for the cookie used for the session.
   , sessionCookieName :: BS.ByteString
   -- | What name to use for the cookie used for CSRF protection.
   , xsrfCookieName    :: BS.ByteString
+  , xsrfCookiePath    :: Maybe BS.ByteString
   -- | What name to use for the header used for CSRF protection.
   , xsrfHeaderName    :: BS.ByteString
   } deriving (Eq, Show, Generic)
@@ -73,8 +75,10 @@ defaultCookieSettings = CookieSettings
     , cookieMaxAge      = Nothing
     , cookieExpires     = Nothing
     , cookieSameSite    = SameSiteLax
+    , cookiePath        = Nothing
     , sessionCookieName = "JWT-Cookie"
     , xsrfCookieName    = "XSRF-TOKEN"
+    , xsrfCookiePath    = Nothing
     , xsrfHeaderName    = "X-XSRF-TOKEN"
     }
 

--- a/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
+++ b/servant-auth-server/src/Servant/Auth/Server/Internal/Cookie.hs
@@ -55,6 +55,7 @@ makeCookie cookieSettings jwtSettings v = do
         , setCookieSecure = case cookieIsSecure cookieSettings of
             Secure -> True
             NotSecure -> False
+        , setCookiePath = cookiePath cookieSettings
         }
 
 makeCookieBS :: ToJWT v => CookieSettings -> JWTSettings -> v -> IO (Maybe BS.ByteString)


### PR DESCRIPTION
Not being able to set path sometimes cause duplicated cookies, one for each subdomain. 