### PR TITLE
Support for GHC 8.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 env:
   - STACK_YAML=stack.yaml
   - STACK_YAML=stack-ghc-8.0.2.yaml
+  - STACK_YAML=stack-ghc-8.2.1.yaml
 
 addons:
   apt:

--- a/servant-auth-client/package.yaml
+++ b/servant-auth-client/package.yaml
@@ -16,7 +16,7 @@ maintainer:          jkarni@gmail.com
 category:            Web, Servant, Authentication
 copyright:           (c) Julian K. Arni
 github:              plow-technologies/servant-auth
-tested-with:         GHC == 7.10.2, GHC == 8.0.1
+tested-with:         GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.1
 
 ghc-options: -Wall
 
@@ -24,7 +24,7 @@ extra-source-files:
   - package.yaml
 
 dependencies:
-  - base                >= 4.7  && < 4.10
+  - base                >= 4.7  && < 4.11
   - text
   - bytestring
   - servant-client      >= 0.7  && < 0.12
@@ -59,11 +59,12 @@ library:
 tests:
   spec:
     main:            Spec.hs
+    other-modules:   [Servant.Auth.ClientSpec]
     source-dirs:     test
     dependencies:
       - servant-auth-client
       - hspec > 2 && < 3
-      - QuickCheck >= 2.8 && < 2.10
+      - QuickCheck >= 2.8 && < 2.11
       - aeson
       - bytestring
       - http-client
@@ -77,8 +78,9 @@ tests:
       - jose
   doctest:
     main:            Doctest.hs
+    other-modules:   []
     source-dirs:     test
     dependencies:
       - doctest >= 0.9 && < 0.12
-      - Glob >= 0.7 && < 0.8
+      - Glob >= 0.7 && < 0.9
       - yaml == 0.8.*

--- a/servant-auth-client/servant-auth-client.cabal
+++ b/servant-auth-client/servant-auth-client.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -36,7 +36,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                >= 4.7  && < 4.10
+      base                >= 4.7  && < 4.11
     , text
     , bytestring
     , servant-client      >= 0.7  && < 0.12
@@ -55,18 +55,15 @@ test-suite doctest
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                >= 4.7  && < 4.10
+      base                >= 4.7  && < 4.11
     , text
     , bytestring
     , servant-client      >= 0.7  && < 0.12
     , servant-auth        == 0.2.*
     , servant             >= 0.7  && < 0.12
     , doctest >= 0.9 && < 0.12
-    , Glob >= 0.7 && < 0.8
+    , Glob >= 0.7 && < 0.9
     , yaml == 0.8.*
-  other-modules:
-      Servant.Auth.ClientSpec
-      Spec
   default-language: Haskell2010
 
 test-suite spec
@@ -77,7 +74,7 @@ test-suite spec
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                >= 4.7  && < 4.10
+      base                >= 4.7  && < 4.11
     , text
     , bytestring
     , servant-client      >= 0.7  && < 0.12
@@ -85,7 +82,7 @@ test-suite spec
     , servant             >= 0.7  && < 0.12
     , servant-auth-client
     , hspec > 2 && < 3
-    , QuickCheck >= 2.8 && < 2.10
+    , QuickCheck >= 2.8 && < 2.11
     , aeson
     , bytestring
     , http-client
@@ -98,6 +95,5 @@ test-suite spec
     , warp
     , jose
   other-modules:
-      Doctest
       Servant.Auth.ClientSpec
   default-language: Haskell2010

--- a/servant-auth-docs/package.yaml
+++ b/servant-auth-docs/package.yaml
@@ -10,7 +10,7 @@ maintainer:          jkarni@gmail.com
 category:            Web, Servant, Authentication
 copyright:           (c) Julian K. Arni
 github:              plow-technologies/servant-auth
-tested-with:         GHC == 7.10.2, GHC == 8.0.1
+tested-with:         GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.1
 
 ghc-options: -Wall
 
@@ -18,7 +18,7 @@ extra-source-files:
   - package.yaml
 
 dependencies:
-  - base >= 4.7 && < 4.10
+  - base >= 4.7 && < 4.11
   - text
   - servant-docs
   - servant
@@ -54,15 +54,17 @@ library:
 tests:
   spec:
     main:            Spec.hs
+    other-modules:   []
     source-dirs:     test
     dependencies:
       - servant-auth-docs
       - hspec > 2 && < 3
-      - QuickCheck >= 2.8 && < 2.10
+      - QuickCheck >= 2.8 && < 2.11
   doctest:
     main:            Doctest.hs
+    other-modules:   []
     source-dirs:     test
     dependencies:
       - doctest >= 0.9 && < 0.12
-      - Glob >= 0.7 && < 0.8
+      - Glob >= 0.7 && < 0.9
       - yaml == 0.8.*

--- a/servant-auth-docs/servant-auth-docs.cabal
+++ b/servant-auth-docs/servant-auth-docs.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -31,7 +31,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
     , text
     , servant-docs
     , servant
@@ -49,17 +49,15 @@ test-suite doctest
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
     , text
     , servant-docs
     , servant
     , servant-auth == 0.2.*
     , lens
     , doctest >= 0.9 && < 0.12
-    , Glob >= 0.7 && < 0.8
+    , Glob >= 0.7 && < 0.9
     , yaml == 0.8.*
-  other-modules:
-      Spec
   default-language: Haskell2010
 
 test-suite spec
@@ -70,7 +68,7 @@ test-suite spec
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
     , text
     , servant-docs
     , servant
@@ -78,7 +76,5 @@ test-suite spec
     , lens
     , servant-auth-docs
     , hspec > 2 && < 3
-    , QuickCheck >= 2.8 && < 2.10
-  other-modules:
-      Doctest
+    , QuickCheck >= 2.8 && < 2.11
   default-language: Haskell2010

--- a/servant-auth-server/package.yaml
+++ b/servant-auth-server/package.yaml
@@ -16,7 +16,7 @@ maintainer:          jkarni@gmail.com
 category:            Web, Servant, Authentication
 copyright:           (c) Julian K. Arni
 github:              plow-technologies/servant-auth
-tested-with:         GHC == 7.10.2, GHC == 8.0.1
+tested-with:         GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.1
 
 extra-source-files:
   - package.yaml
@@ -24,7 +24,7 @@ extra-source-files:
 ghc-options: -Wall
 
 dependencies:
-  - base                    >= 4.7  && < 4.10
+  - base                    >= 4.7  && < 4.11
   - text                    >= 1    && < 2
   - servant-auth            == 0.2.*
   # We have an orphan instance for SetCookie, so we need to be careful about upper bounds.
@@ -36,7 +36,7 @@ dependencies:
   - case-insensitive        >= 1.2  && < 1.3
   - jose                    >= 0.5  && < 0.6
   - monad-time              >= 0.2  && < 0.3
-  - time                    >= 1.5  && < 1.7
+  - time                    >= 1.5  && < 1.9
   - servant-server          >= 0.9.1  && < 0.12
   - base64-bytestring       >= 1    && < 2
   - blaze-builder           >= 0.4  && < 0.5
@@ -79,11 +79,12 @@ library:
 tests:
   spec:
     main:            Spec.hs
+    other-modules:   [Servant.Auth.ServerSpec]
     source-dirs:     test
     dependencies:
       - servant-auth-server
       - hspec > 2 && < 3
-      - QuickCheck >= 2.8 && < 2.10
+      - QuickCheck >= 2.8 && < 2.11
       - aeson
       - lens-aeson
       - warp

--- a/servant-auth-server/servant-auth-server.cabal
+++ b/servant-auth-server/servant-auth-server.cabal
@@ -1,9 +1,9 @@
--- This file has been generated from package.yaml by hpack version 0.17.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           servant-auth-server
-version:        0.2.8.0
+version:        0.3.0.0
 synopsis:       servant-server/servant-auth compatibility
 description:    This package provides the required instances for using the @Auth@ combinator
                 in your 'servant' server.
@@ -36,7 +36,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                    >= 4.7  && < 4.10
+      base                    >= 4.7  && < 4.11
     , text                    >= 1    && < 2
     , servant-auth            == 0.2.*
     , cookie                  >= 0.4  && < 0.4.2.2
@@ -45,9 +45,9 @@ library
     , bytestring              >= 0.10 && < 0.11
     , bytestring-conversion   >= 0.3  && < 0.4
     , case-insensitive        >= 1.2  && < 1.3
-    , jose                    >= 0.5  && < 0.6
+    , jose                    >= 0.5  && < 0.7
     , monad-time              >= 0.2  && < 0.3
-    , time                    >= 1.5  && < 1.7
+    , time                    >= 1.5  && < 1.9
     , servant-server          >= 0.9.1  && < 0.12
     , base64-bytestring       >= 1    && < 2
     , blaze-builder           >= 0.4  && < 0.5
@@ -82,7 +82,7 @@ executable readme
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall -pgmL markdown-unlit
   build-depends:
-      base                    >= 4.7  && < 4.10
+      base                    >= 4.7  && < 4.11
     , text                    >= 1    && < 2
     , servant-auth            == 0.2.*
     , cookie                  >= 0.4  && < 0.4.2.2
@@ -91,9 +91,9 @@ executable readme
     , bytestring              >= 0.10 && < 0.11
     , bytestring-conversion   >= 0.3  && < 0.4
     , case-insensitive        >= 1.2  && < 1.3
-    , jose                    >= 0.5  && < 0.6
+    , jose                    >= 0.5  && < 0.7
     , monad-time              >= 0.2  && < 0.3
-    , time                    >= 1.5  && < 1.7
+    , time                    >= 1.5  && < 1.9
     , servant-server          >= 0.9.1  && < 0.12
     , base64-bytestring       >= 1    && < 2
     , blaze-builder           >= 0.4  && < 0.5
@@ -122,7 +122,7 @@ test-suite spec
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base                    >= 4.7  && < 4.10
+      base                    >= 4.7  && < 4.11
     , text                    >= 1    && < 2
     , servant-auth            == 0.2.*
     , cookie                  >= 0.4  && < 0.4.2.2
@@ -131,9 +131,9 @@ test-suite spec
     , bytestring              >= 0.10 && < 0.11
     , bytestring-conversion   >= 0.3  && < 0.4
     , case-insensitive        >= 1.2  && < 1.3
-    , jose                    >= 0.5  && < 0.6
+    , jose                    >= 0.5  && < 0.7
     , monad-time              >= 0.2  && < 0.3
-    , time                    >= 1.5  && < 1.7
+    , time                    >= 1.5  && < 1.9
     , servant-server          >= 0.9.1  && < 0.12
     , base64-bytestring       >= 1    && < 2
     , blaze-builder           >= 0.4  && < 0.5
@@ -148,7 +148,7 @@ test-suite spec
     , tagged                  >= 0.7.3 && < 0.9
     , servant-auth-server
     , hspec > 2 && < 3
-    , QuickCheck >= 2.8 && < 2.10
+    , QuickCheck >= 2.8 && < 2.11
     , aeson
     , lens-aeson
     , warp
@@ -156,6 +156,5 @@ test-suite spec
     , http-types
     , http-client >= 0.4 && < 0.6
   other-modules:
-      Doctest
       Servant.Auth.ServerSpec
   default-language: Haskell2010

--- a/servant-auth-swagger/package.yaml
+++ b/servant-auth-swagger/package.yaml
@@ -10,7 +10,7 @@ maintainer:          jkarni@gmail.com
 category:            Web, Servant, Authentication
 copyright:           (c) Julian K. Arni
 github:              plow-technologies/servant-auth
-tested-with:         GHC == 7.10.2, GHC == 8.0.1
+tested-with:         GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.1
 
 ghc-options: -Wall
 
@@ -18,7 +18,7 @@ extra-source-files:
   - package.yaml
 
 dependencies:
-  - base >= 4.7 && < 4.10
+  - base >= 4.7 && < 4.11
   - text
   - servant-swagger
   - swagger2 >= 2 && < 3
@@ -55,16 +55,18 @@ library:
 tests:
   spec:
     main:            Spec.hs
+    other-modules:   [Servant.Auth.SwaggerSpec]
     source-dirs:     test
     dependencies:
       - servant-auth-swagger
       - yaml
       - hspec > 2 && < 3
-      - QuickCheck >= 2.8 && < 2.10
+      - QuickCheck >= 2.8 && < 2.11
   doctest:
     main:            Doctest.hs
+    other-modules:   []
     source-dirs:     test
     dependencies:
       - doctest >= 0.9 && < 0.12
-      - Glob >= 0.7 && < 0.8
+      - Glob >= 0.7 && < 0.9
       - yaml == 0.8.*

--- a/servant-auth-swagger/servant-auth-swagger.cabal
+++ b/servant-auth-swagger/servant-auth-swagger.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -31,7 +31,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
     , text
     , servant-swagger
     , swagger2 >= 2 && < 3
@@ -50,7 +50,7 @@ test-suite doctest
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
     , text
     , servant-swagger
     , swagger2 >= 2 && < 3
@@ -58,11 +58,8 @@ test-suite doctest
     , servant-auth == 0.2.*
     , lens
     , doctest >= 0.9 && < 0.12
-    , Glob >= 0.7 && < 0.8
+    , Glob >= 0.7 && < 0.9
     , yaml == 0.8.*
-  other-modules:
-      Servant.Auth.SwaggerSpec
-      Spec
   default-language: Haskell2010
 
 test-suite spec
@@ -73,7 +70,7 @@ test-suite spec
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
     , text
     , servant-swagger
     , swagger2 >= 2 && < 3
@@ -83,8 +80,7 @@ test-suite spec
     , servant-auth-swagger
     , yaml
     , hspec > 2 && < 3
-    , QuickCheck >= 2.8 && < 2.10
+    , QuickCheck >= 2.8 && < 2.11
   other-modules:
-      Doctest
       Servant.Auth.SwaggerSpec
   default-language: Haskell2010

--- a/servant-auth/package.yaml
+++ b/servant-auth/package.yaml
@@ -18,7 +18,7 @@ maintainer:          jkarni@gmail.com
 category:            Web, Servant, Authentication
 copyright:           (c) Julian K. Arni
 github:              plow-technologies/servant-auth
-tested-with:         GHC == 7.10.2, GHC == 8.0.1
+tested-with:         GHC == 7.10.2, GHC == 8.0.1, GHC == 8.2.1
 
 extra-source-files:
   - package.yaml
@@ -26,7 +26,7 @@ extra-source-files:
 ghc-options: -Wall
 
 dependencies:
-  - base >= 4.7 && < 4.10
+  - base >= 4.7 && < 4.11
 
 default-extensions:
   - AutoDeriveTypeable
@@ -56,15 +56,18 @@ library:
 tests:
   spec:
     main:            Spec.hs
+    other-modules:   []
     source-dirs:     test
     dependencies:
       - servant-auth
       - hspec > 2 && < 3
-      - QuickCheck >= 2.8 && < 2.10
+      - QuickCheck >= 2.8 && < 2.11
+
   doctest:
     main:            Doctest.hs
+    other-modules:   []
     source-dirs:     test
     dependencies:
       - doctest >= 0.9 && < 0.12
-      - Glob >= 0.7 && < 0.8
+      - Glob >= 0.7 && < 0.9
       - yaml == 0.8.*

--- a/servant-auth/servant-auth.cabal
+++ b/servant-auth/servant-auth.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.15.0.
+-- This file has been generated from package.yaml by hpack version 0.17.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -38,7 +38,7 @@ library
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
   exposed-modules:
       Servant.Auth
   default-language: Haskell2010
@@ -51,12 +51,10 @@ test-suite doctest
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
     , doctest >= 0.9 && < 0.12
-    , Glob >= 0.7 && < 0.8
+    , Glob >= 0.7 && < 0.9
     , yaml == 0.8.*
-  other-modules:
-      Spec
   default-language: Haskell2010
 
 test-suite spec
@@ -67,10 +65,8 @@ test-suite spec
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >= 4.7 && < 4.10
+      base >= 4.7 && < 4.11
     , servant-auth
     , hspec > 2 && < 3
-    , QuickCheck >= 2.8 && < 2.10
-  other-modules:
-      Doctest
+    , QuickCheck >= 2.8 && < 2.11
   default-language: Haskell2010

--- a/stack-ghc-8.2.1.yaml
+++ b/stack-ghc-8.2.1.yaml
@@ -1,0 +1,15 @@
+flags: {}
+apply-ghc-options: targets
+packages:
+- servant-auth
+- servant-auth-server
+- servant-auth-client
+- servant-auth-docs
+- servant-auth-swagger
+extra-deps:
+- jose-0.5.0.5
+- servant-0.11
+- servant-client-0.11
+- servant-docs-0.10.0.1
+- servant-server-0.11
+resolver: nightly-2017-09-07


### PR DESCRIPTION
Created `stack-ghc-8.2.1.yaml` which contains resolver `nightly-2017-09-07`.

Updated `travis.yaml` and increased upper bounds of some dependencies. Could not update `jose` to latest version (0.6.0.3) because it contains large changes and also not the purpose of this PR.